### PR TITLE
Use OpenJDK8 to avoid mvel2 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-alpine
+FROM openjdk:8-alpine
 
 ARG version
 


### PR DESCRIPTION
## Problem

browserup's REST API couldn't work on JAVA 10 and later because of MVEL2's bug
see: https://github.com/mvel/mvel/issues/159

## Solution

Just down the version :(